### PR TITLE
Gradle options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .gradle
-build/
-out/
+**/.project
+**/bin/
+**/build/
+**/out/
 .idea/
 gettext-lib/src/main/java/org/mini2Dx/gettext/antlr/
 

--- a/gettext-gradle-plugin/src/main/groovy/org/mini2Dx/gettext/plugin/GetTextSource.java
+++ b/gettext-gradle-plugin/src/main/groovy/org/mini2Dx/gettext/plugin/GetTextSource.java
@@ -16,19 +16,19 @@
 package org.mini2Dx.gettext.plugin;
 
 public class GetTextSource {
-    private final String name;
-    public String srcDir;
-    public String include;
-    public String exclude;
-    public String[] excludes;
-    public String commentFormat = "#.";
-    public String outputFilename;
+	private final String name;
+	public String srcDir;
+	public String include;
+	public String exclude;
+	public String[] excludes;
+	public String commentFormat = "#.";
+	public String outputFilename;
 
-    public GetTextSource(String name) {
-        this.name = name;
-    }
+	public GetTextSource(String name) {
+		this.name = name;
+	}
 
-    public String getName() {
-        return name;
-    }
+	public String getName() {
+		return name;
+	}
 }

--- a/gettext-gradle-plugin/src/main/groovy/org/mini2Dx/gettext/plugin/GetTextSource.java
+++ b/gettext-gradle-plugin/src/main/groovy/org/mini2Dx/gettext/plugin/GetTextSource.java
@@ -16,16 +16,18 @@
 package org.mini2Dx.gettext.plugin;
 
 public class GetTextSource {
-	private final String name;
-	public String srcDir;
-	public String include;
-	public String outputFilename;
+    private final String name;
+    public String srcDir;
+    public String include;
+    public String exclude;
+    public String[] excludes;
+    public String outputFilename;
 
-	public GetTextSource(String name) {
-		this.name = name;
-	}
+    public GetTextSource(String name) {
+        this.name = name;
+    }
 
-	public String getName() {
-		return name;
-	}
+    public String getName() {
+        return name;
+    }
 }

--- a/gettext-gradle-plugin/src/main/groovy/org/mini2Dx/gettext/plugin/GetTextSource.java
+++ b/gettext-gradle-plugin/src/main/groovy/org/mini2Dx/gettext/plugin/GetTextSource.java
@@ -21,6 +21,7 @@ public class GetTextSource {
     public String include;
     public String exclude;
     public String[] excludes;
+    public String commentFormat = "#.";
     public String outputFilename;
 
     public GetTextSource(String name) {

--- a/gettext-gradle-plugin/src/main/groovy/org/mini2Dx/gettext/plugin/task/GeneratePotTask.groovy
+++ b/gettext-gradle-plugin/src/main/groovy/org/mini2Dx/gettext/plugin/task/GeneratePotTask.groovy
@@ -61,7 +61,7 @@ class GeneratePotTask extends DefaultTask {
     }
 
     private void generateTranslationEntries(File file, String relativePath, List<TranslationEntry> results) {
-        final SourceFile sourceFile = SourceFileParser.parse(file, relativePath);
+        final SourceFile sourceFile = SourceFileParser.parse(file, relativePath, source.commentFormat);
         sourceFile.getTranslationEntries(results);
         sourceFile.dispose();
     }

--- a/gettext-gradle-plugin/src/main/groovy/org/mini2Dx/gettext/plugin/task/GeneratePotTask.groovy
+++ b/gettext-gradle-plugin/src/main/groovy/org/mini2Dx/gettext/plugin/task/GeneratePotTask.groovy
@@ -31,6 +31,16 @@ class GeneratePotTask extends DefaultTask {
     public void run() throws IOException {
         final FileTree sourceFiles = project.fileTree(source.srcDir) {
             include source.include;
+
+            if(source.excludes != null) {
+                for (String excludePath : source.excludes) {
+                    exclude excludePath;
+                }
+            }
+
+            if(source.exclude != null) {
+                exclude source.exclude;
+            }
         };
 
         final PoFile poFile = new PoFile(Locale.ENGLISH);

--- a/gettext-gradle-plugin/src/main/java/org/mini2Dx/gettext/plugin/file/JavaFile.java
+++ b/gettext-gradle-plugin/src/main/java/org/mini2Dx/gettext/plugin/file/JavaFile.java
@@ -63,9 +63,9 @@ public class JavaFile extends JavaBaseListener implements SourceFile {
 				if(comment.startsWith("//")) {
 					comment = comment.substring(2);
 				}
-				if (comment.startsWith(commentFormat)) {
-                    comment = comment.substring(commentFormat.length());
-                } else {
+				if(comment.startsWith(commentFormat)) {
+					comment = comment.substring(commentFormat.length());
+				} else {
 					continue;
 				}
 				comments.put(token.getLine(), comment);

--- a/gettext-gradle-plugin/src/main/java/org/mini2Dx/gettext/plugin/file/JavaFile.java
+++ b/gettext-gradle-plugin/src/main/java/org/mini2Dx/gettext/plugin/file/JavaFile.java
@@ -49,7 +49,7 @@ public class JavaFile extends JavaBaseListener implements SourceFile {
 	private ParseState parseState = ParseState.CLASS;
 	private boolean nextFieldIsStatic = true;
 
-	public JavaFile(InputStream inputStream, String relativePath) throws IOException {
+	public JavaFile(InputStream inputStream, String relativePath, String commentFormat) throws IOException {
 		super();
 		this.relativePath = relativePath;
 
@@ -63,9 +63,9 @@ public class JavaFile extends JavaBaseListener implements SourceFile {
 				if(comment.startsWith("//")) {
 					comment = comment.substring(2);
 				}
-				if(comment.startsWith("#.")) {
-					comment = comment.substring(2);
-				} else {
+				if (comment.startsWith(commentFormat)) {
+                    comment = comment.substring(commentFormat.length());
+                } else {
 					continue;
 				}
 				comments.put(token.getLine(), comment);

--- a/gettext-gradle-plugin/src/main/java/org/mini2Dx/gettext/plugin/file/LuaFile.java
+++ b/gettext-gradle-plugin/src/main/java/org/mini2Dx/gettext/plugin/file/LuaFile.java
@@ -41,7 +41,7 @@ public class LuaFile extends LuaBaseListener implements SourceFile {
 	private final Map<String, String> variables = new HashMap<String, String>();
 	private final Map<Integer, String> comments = new HashMap<Integer, String>();
 
-	public LuaFile(InputStream inputStream, String relativePath) throws IOException {
+	public LuaFile(InputStream inputStream, String relativePath, String commentFormat) throws IOException {
 		super();
 		this.relativePath = relativePath;
 
@@ -54,8 +54,8 @@ public class LuaFile extends LuaBaseListener implements SourceFile {
 				if(comment.startsWith("--")) {
 					comment = comment.substring(2);
 				}
-				if(comment.startsWith("#.")) {
-					comment = comment.substring(2);
+				if(comment.startsWith(commentFormat)) {
+					comment = comment.substring(commentFormat.length());
 				} else {
 					continue;
 				}

--- a/gettext-gradle-plugin/src/main/java/org/mini2Dx/gettext/plugin/file/SourceFileParser.java
+++ b/gettext-gradle-plugin/src/main/java/org/mini2Dx/gettext/plugin/file/SourceFileParser.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 
 public class SourceFileParser {
 
-	public static SourceFile parse(File file, String relativePath) throws IOException {
+	public static SourceFile parse(File file, String relativePath, String commentFormat) throws IOException {
 		final String filename = file.getName().toLowerCase();
 		if(!filename.contains(".")) {
 			throw new RuntimeException("Cannot file type for file " + relativePath);
@@ -29,11 +29,11 @@ public class SourceFileParser {
 		final String suffix = filename.substring(filename.lastIndexOf('.') + 1);
 		switch(suffix) {
 		case "lua":
-			return new LuaFile(new FileInputStream(file), relativePath);
+			return new LuaFile(new FileInputStream(file), relativePath, commentFormat);
 		case "java":
-			return new JavaFile(new FileInputStream(file), relativePath);
+			return new JavaFile(new FileInputStream(file), relativePath, commentFormat);
 		case "txt":
-			return new TextFile(new FileInputStream(file), relativePath);
+			return new TextFile(new FileInputStream(file), relativePath, commentFormat);
 		default:
 			throw new RuntimeException("Unable to generate .pot file from " + suffix + " file type");
 		}

--- a/gettext-gradle-plugin/src/main/java/org/mini2Dx/gettext/plugin/file/TextFile.java
+++ b/gettext-gradle-plugin/src/main/java/org/mini2Dx/gettext/plugin/file/TextFile.java
@@ -28,7 +28,7 @@ public class TextFile implements SourceFile {
 	private final List<TranslationEntry> translationEntries = new ArrayList<TranslationEntry>();
 	private final String relativePath;
 
-	public TextFile(InputStream inputStream, String relativePath) throws IOException {
+	public TextFile(InputStream inputStream, String relativePath, String commentFormat) throws IOException {
 		super();
 		this.relativePath = relativePath;
 
@@ -42,8 +42,8 @@ public class TextFile implements SourceFile {
 				entry = new TranslationEntry();
 			}
 			if(!line.trim().isEmpty()) {
-				if(line.startsWith("#.")) {
-					entry.getExtractedComments().add(line.substring(2).trim());
+				if(line.startsWith(commentFormat)) {
+					entry.getExtractedComments().add(line.substring(commentFormat.length()).trim());
 				} else {
 					entry.setReference(relativePath + ":" + lineNumber);
 					entry.setId(line);

--- a/gettext-gradle-plugin/src/test/java/org/mini2Dx/gettext/plugin/file/JavaFileTest.java
+++ b/gettext-gradle-plugin/src/test/java/org/mini2Dx/gettext/plugin/file/JavaFileTest.java
@@ -23,14 +23,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class JavaFileTest {
-    private static final String TR_FILENAME = "SampleTr.java";
-    private static final String TRC_FILENAME = "SampleTrc.java";
-    private static final String TRN_FILENAME = "SampleTrn.java";
-    private static final String TRNC_FILENAME = "SampleTrnc.java";
-    private static final String COMMENT_FORMAT = "#.";
+	private static final String TR_FILENAME = "SampleTr.java";
+	private static final String TRC_FILENAME = "SampleTrc.java";
+	private static final String TRN_FILENAME = "SampleTrn.java";
+	private static final String TRNC_FILENAME = "SampleTrnc.java";
+	private static final String COMMENT_FORMAT = "#.";
 
-    private static final String TR_CUSTOM_COMMENT_FILENAME = "SampleTrCustomComment.java";
-    private static final String CUSTOM_COMMENT_FORMAT = " #. ";
+	private static final String TR_CUSTOM_COMMENT_FILENAME = "SampleTrCustomComment.java";
+	private static final String CUSTOM_COMMENT_FORMAT = " #. ";
 
 	private static JavaFile TR_FILE, TRC_FILE, TRN_FILE, TRNC_FILE, TR_CUSTOM_COMMENT_FILE;
 
@@ -50,8 +50,8 @@ public class JavaFileTest {
 		TR_FILE.dispose();
 		TRC_FILE.dispose();
 		TRN_FILE.dispose();
-        TRNC_FILE.dispose();
-        TR_CUSTOM_COMMENT_FILE.dispose();
+		TRNC_FILE.dispose();
+		TR_CUSTOM_COMMENT_FILE.dispose();
 	}
 
 	@After
@@ -257,7 +257,7 @@ public class JavaFileTest {
 		Assert.assertEquals("Static ref multi lines", entry6.getIdPlural());
 		Assert.assertEquals(1, entry6.getExtractedComments().size());
 		Assert.assertEquals("Comment 2", entry6.getExtractedComments().get(0));
-    }
+	}
 
 	@Test
 	public void testTrCustomComment() {

--- a/gettext-gradle-plugin/src/test/java/org/mini2Dx/gettext/plugin/file/JavaFileTest.java
+++ b/gettext-gradle-plugin/src/test/java/org/mini2Dx/gettext/plugin/file/JavaFileTest.java
@@ -23,21 +23,26 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class JavaFileTest {
-	private static final String TR_FILENAME = "SampleTr.java";
-	private static final String TRC_FILENAME = "SampleTrc.java";
-	private static final String TRN_FILENAME = "SampleTrn.java";
-	private static final String TRNC_FILENAME = "SampleTrnc.java";
+    private static final String TR_FILENAME = "SampleTr.java";
+    private static final String TRC_FILENAME = "SampleTrc.java";
+    private static final String TRN_FILENAME = "SampleTrn.java";
+    private static final String TRNC_FILENAME = "SampleTrnc.java";
+    private static final String COMMENT_FORMAT = "#.";
 
-	private static JavaFile TR_FILE, TRC_FILE, TRN_FILE, TRNC_FILE;
+    private static final String TR_CUSTOM_COMMENT_FILENAME = "SampleTrCustomComment.java";
+    private static final String CUSTOM_COMMENT_FORMAT = " #. ";
+
+	private static JavaFile TR_FILE, TRC_FILE, TRN_FILE, TRNC_FILE, TR_CUSTOM_COMMENT_FILE;
 
 	private final List<TranslationEntry> results = new ArrayList<TranslationEntry>();
 
 	@BeforeClass
 	public static void loadFiles() throws IOException {
-		TR_FILE = new JavaFile(JavaFileTest.class.getResourceAsStream("/" + TR_FILENAME), TR_FILENAME);
-		TRC_FILE = new JavaFile(JavaFileTest.class.getResourceAsStream("/" + TRC_FILENAME), TRC_FILENAME);
-		TRN_FILE = new JavaFile(JavaFileTest.class.getResourceAsStream("/" + TRN_FILENAME), TRN_FILENAME);
-		TRNC_FILE = new JavaFile(JavaFileTest.class.getResourceAsStream("/" + TRNC_FILENAME), TRNC_FILENAME);
+		TR_FILE = new JavaFile(JavaFileTest.class.getResourceAsStream("/" + TR_FILENAME), TR_FILENAME, COMMENT_FORMAT);
+		TRC_FILE = new JavaFile(JavaFileTest.class.getResourceAsStream("/" + TRC_FILENAME), TRC_FILENAME, COMMENT_FORMAT);
+		TRN_FILE = new JavaFile(JavaFileTest.class.getResourceAsStream("/" + TRN_FILENAME), TRN_FILENAME, COMMENT_FORMAT);
+		TRNC_FILE = new JavaFile(JavaFileTest.class.getResourceAsStream("/" + TRNC_FILENAME), TRNC_FILENAME, COMMENT_FORMAT);
+		TR_CUSTOM_COMMENT_FILE = new JavaFile(JavaFileTest.class.getResourceAsStream("/" + TR_CUSTOM_COMMENT_FILENAME), TR_CUSTOM_COMMENT_FILENAME, CUSTOM_COMMENT_FORMAT);
 	}
 
 	@AfterClass
@@ -45,7 +50,8 @@ public class JavaFileTest {
 		TR_FILE.dispose();
 		TRC_FILE.dispose();
 		TRN_FILE.dispose();
-		TRNC_FILE.dispose();
+        TRNC_FILE.dispose();
+        TR_CUSTOM_COMMENT_FILE.dispose();
 	}
 
 	@After
@@ -249,6 +255,49 @@ public class JavaFileTest {
 		Assert.assertEquals("ctx6", entry6.getContext());
 		Assert.assertEquals("Static ref multi line", entry6.getId());
 		Assert.assertEquals("Static ref multi lines", entry6.getIdPlural());
+		Assert.assertEquals(1, entry6.getExtractedComments().size());
+		Assert.assertEquals("Comment 2", entry6.getExtractedComments().get(0));
+    }
+
+	@Test
+	public void testTrCustomComment() {
+		TR_CUSTOM_COMMENT_FILE.getTranslationEntries(results);
+		Assert.assertEquals(7, results.size());
+
+		final TranslationEntry entry0 = results.get(0);
+		Assert.assertEquals(TR_CUSTOM_COMMENT_FILENAME + ":17", entry0.getReference());
+		Assert.assertEquals("Hello World!", entry0.getId());
+		Assert.assertEquals(0, entry0.getExtractedComments().size());
+
+		final TranslationEntry entry1 = results.get(1);
+		Assert.assertEquals(TR_CUSTOM_COMMENT_FILENAME + ":18", entry1.getReference());
+		Assert.assertEquals("Multipart same line", entry1.getId());
+		Assert.assertEquals(0, entry1.getExtractedComments().size());
+
+		final TranslationEntry entry2 = results.get(2);
+		Assert.assertEquals(TR_CUSTOM_COMMENT_FILENAME + ":19", entry2.getReference());
+		Assert.assertEquals("Multipart multi line", entry2.getId());
+		Assert.assertEquals(0, entry2.getExtractedComments().size());
+
+		final TranslationEntry entry3 = results.get(3);
+		Assert.assertEquals(TR_CUSTOM_COMMENT_FILENAME + ":24", entry3.getReference());
+		Assert.assertEquals("With comment", entry3.getId());
+		Assert.assertEquals(1, entry3.getExtractedComments().size());
+		Assert.assertEquals("Comment 1", entry3.getExtractedComments().get(0));
+
+		final TranslationEntry entry4 = results.get(4);
+		Assert.assertEquals(TR_CUSTOM_COMMENT_FILENAME + ":26", entry4.getReference());
+		Assert.assertEquals("Static ref", entry4.getId());
+		Assert.assertEquals(0, entry4.getExtractedComments().size());
+
+		final TranslationEntry entry5 = results.get(5);
+		Assert.assertEquals(TR_CUSTOM_COMMENT_FILENAME + ":30", entry5.getReference());
+		Assert.assertEquals("Static ref multi part", entry5.getId());
+		Assert.assertEquals(0, entry5.getExtractedComments().size());
+
+		final TranslationEntry entry6 = results.get(6);
+		Assert.assertEquals(TR_CUSTOM_COMMENT_FILENAME + ":34", entry6.getReference());
+		Assert.assertEquals("Static ref multi line", entry6.getId());
 		Assert.assertEquals(1, entry6.getExtractedComments().size());
 		Assert.assertEquals("Comment 2", entry6.getExtractedComments().get(0));
 	}

--- a/gettext-gradle-plugin/src/test/java/org/mini2Dx/gettext/plugin/file/LuaFileTest.java
+++ b/gettext-gradle-plugin/src/test/java/org/mini2Dx/gettext/plugin/file/LuaFileTest.java
@@ -27,9 +27,12 @@ public class LuaFileTest {
 	private static final String TRC_FILENAME = "sampleTrc.lua";
 	private static final String TRN_FILENAME = "sampleTrn.lua";
 	private static final String TRNC_FILENAME = "sampleTrnc.lua";
-    private static final String COMMENT_FORMAT = "#.";
+	private static final String COMMENT_FORMAT = "#.";
 
-	private static LuaFile TR_FILE, TRC_FILE, TRN_FILE, TRNC_FILE;
+	private static final String TR_CUSTOM_COMMENT_FILENAME = "sampleTrCustomComment.lua";
+	private static final String CUSTOM_COMMENT_FORMAT = " #. ";
+
+	private static LuaFile TR_FILE, TRC_FILE, TRN_FILE, TRNC_FILE, TR_CUSTOM_COMMENT_FILE;
 
 	private final List<TranslationEntry> results = new ArrayList<TranslationEntry>();
 
@@ -39,6 +42,7 @@ public class LuaFileTest {
 		TRC_FILE = new LuaFile(LuaFileTest.class.getResourceAsStream("/" + TRC_FILENAME), TRC_FILENAME, COMMENT_FORMAT);
 		TRN_FILE = new LuaFile(LuaFileTest.class.getResourceAsStream("/" + TRN_FILENAME), TRN_FILENAME, COMMENT_FORMAT);
 		TRNC_FILE = new LuaFile(LuaFileTest.class.getResourceAsStream("/" + TRNC_FILENAME), TRNC_FILENAME, COMMENT_FORMAT);
+		TR_CUSTOM_COMMENT_FILE = new LuaFile(LuaFileTest.class.getResourceAsStream("/" + TR_CUSTOM_COMMENT_FILENAME), TR_CUSTOM_COMMENT_FILENAME, CUSTOM_COMMENT_FORMAT);
 	}
 
 	@AfterClass
@@ -47,6 +51,7 @@ public class LuaFileTest {
 		TRC_FILE.dispose();
 		TRN_FILE.dispose();
 		TRNC_FILE.dispose();
+		TR_CUSTOM_COMMENT_FILE.dispose();
 	}
 
 	@After
@@ -178,6 +183,34 @@ public class LuaFileTest {
 		Assert.assertEquals("ctx3", entry3.getContext());
 		Assert.assertEquals("Tr with args and comment", entry3.getId());
 		Assert.assertEquals("Tr with args and comment plural", entry3.getIdPlural());
+		Assert.assertEquals(1, entry3.getExtractedComments().size());
+		Assert.assertEquals("Comment 1", entry3.getExtractedComments().get(0));
+	}
+
+	@Test
+	public void testTrCustomComment() {
+		TR_CUSTOM_COMMENT_FILE.getTranslationEntries(results);
+
+		Assert.assertEquals(4, results.size());
+
+		final TranslationEntry entry0 = results.get(0);
+		Assert.assertEquals(TR_CUSTOM_COMMENT_FILENAME + ":1", entry0.getReference());
+		Assert.assertEquals("Simple", entry0.getId());
+		Assert.assertEquals(0, entry0.getExtractedComments().size());
+
+		final TranslationEntry entry1 = results.get(1);
+		Assert.assertEquals(TR_CUSTOM_COMMENT_FILENAME + ":3", entry1.getReference());
+		Assert.assertEquals("Multi part", entry1.getId());
+		Assert.assertEquals(0, entry1.getExtractedComments().size());
+
+		final TranslationEntry entry2 = results.get(2);
+		Assert.assertEquals(TR_CUSTOM_COMMENT_FILENAME + ":6", entry2.getReference());
+		Assert.assertEquals("Variable Ref", entry2.getId());
+		Assert.assertEquals(0, entry2.getExtractedComments().size());
+
+		final TranslationEntry entry3 = results.get(3);
+		Assert.assertEquals(TR_CUSTOM_COMMENT_FILENAME + ":9", entry3.getReference());
+		Assert.assertEquals("Tr with args and comment", entry3.getId());
 		Assert.assertEquals(1, entry3.getExtractedComments().size());
 		Assert.assertEquals("Comment 1", entry3.getExtractedComments().get(0));
 	}

--- a/gettext-gradle-plugin/src/test/java/org/mini2Dx/gettext/plugin/file/LuaFileTest.java
+++ b/gettext-gradle-plugin/src/test/java/org/mini2Dx/gettext/plugin/file/LuaFileTest.java
@@ -27,6 +27,7 @@ public class LuaFileTest {
 	private static final String TRC_FILENAME = "sampleTrc.lua";
 	private static final String TRN_FILENAME = "sampleTrn.lua";
 	private static final String TRNC_FILENAME = "sampleTrnc.lua";
+    private static final String COMMENT_FORMAT = "#.";
 
 	private static LuaFile TR_FILE, TRC_FILE, TRN_FILE, TRNC_FILE;
 
@@ -34,10 +35,10 @@ public class LuaFileTest {
 
 	@BeforeClass
 	public static void loadFiles() throws IOException {
-		TR_FILE = new LuaFile(LuaFileTest.class.getResourceAsStream("/" + TR_FILENAME), TR_FILENAME);
-		TRC_FILE = new LuaFile(LuaFileTest.class.getResourceAsStream("/" + TRC_FILENAME), TRC_FILENAME);
-		TRN_FILE = new LuaFile(LuaFileTest.class.getResourceAsStream("/" + TRN_FILENAME), TRN_FILENAME);
-		TRNC_FILE = new LuaFile(LuaFileTest.class.getResourceAsStream("/" + TRNC_FILENAME), TRNC_FILENAME);
+		TR_FILE = new LuaFile(LuaFileTest.class.getResourceAsStream("/" + TR_FILENAME), TR_FILENAME, COMMENT_FORMAT);
+		TRC_FILE = new LuaFile(LuaFileTest.class.getResourceAsStream("/" + TRC_FILENAME), TRC_FILENAME, COMMENT_FORMAT);
+		TRN_FILE = new LuaFile(LuaFileTest.class.getResourceAsStream("/" + TRN_FILENAME), TRN_FILENAME, COMMENT_FORMAT);
+		TRNC_FILE = new LuaFile(LuaFileTest.class.getResourceAsStream("/" + TRNC_FILENAME), TRNC_FILENAME, COMMENT_FORMAT);
 	}
 
 	@AfterClass

--- a/gettext-gradle-plugin/src/test/java/org/mini2Dx/gettext/plugin/file/TextFileTest.java
+++ b/gettext-gradle-plugin/src/test/java/org/mini2Dx/gettext/plugin/file/TextFileTest.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public class TextFileTest {
 	private static final String FILENAME = "sample.txt";
-    private static final String COMMENT_FORMAT = "#.";
+	private static final String COMMENT_FORMAT = "#.";
 
 	@Test
 	public void testTextFile() throws IOException {

--- a/gettext-gradle-plugin/src/test/java/org/mini2Dx/gettext/plugin/file/TextFileTest.java
+++ b/gettext-gradle-plugin/src/test/java/org/mini2Dx/gettext/plugin/file/TextFileTest.java
@@ -10,10 +10,11 @@ import java.util.List;
 
 public class TextFileTest {
 	private static final String FILENAME = "sample.txt";
+    private static final String COMMENT_FORMAT = "#.";
 
 	@Test
 	public void testTextFile() throws IOException {
-		final TextFile textFile = new TextFile(TextFileTest.class.getResourceAsStream("/" + FILENAME), FILENAME);
+		final TextFile textFile = new TextFile(TextFileTest.class.getResourceAsStream("/" + FILENAME), FILENAME, COMMENT_FORMAT);
 		final List<TranslationEntry> results = new ArrayList<TranslationEntry>();
 		textFile.getTranslationEntries(results);
 

--- a/gettext-gradle-plugin/src/test/resources/SampleTrCustomComment.java
+++ b/gettext-gradle-plugin/src/test/resources/SampleTrCustomComment.java
@@ -1,0 +1,36 @@
+import org.mini2Dx.gettext.GetText;
+
+import java.util.Locale;
+
+/**
+ *  HelloWorld.java
+ */
+public class HelloWorld  {
+	private static final String STATIC_REF = "Static ref";
+	private static final String STATIC_REF_MULTI_PART = "Static ref " + "multi " + "part";
+	private static final String STATIC_REF_MULTI_LINE = "Static ref " +
+			"multi " +
+			"line";
+
+	public static void tr() {
+		System.out.println("Non translated string 1");
+		System.out.println(GetText.tr("Hello World!"));
+		final String result = GetText.tr("Multipart " + "same " + "line" ,1);
+		System.out.println(GetText.tr("Multipart " +
+				"multi " +
+				"line"));
+
+		// #. Comment 1
+		System.out.println(GetText.tr("With comment"));
+		System.out.println(
+				GetText.tr(STATIC_REF));
+		System.out.println("Non translated string 2");
+
+		final String result2 = STATIC_REF_MULTI_PART;
+		System.out.println(GetText.tr(Locale.ENGLISH,
+				result2));
+
+		// #. Comment 2
+		System.out.println(GetText.tr(Locale.ENGLISH, STATIC_REF_MULTI_LINE, 7));
+	}
+}

--- a/gettext-gradle-plugin/src/test/resources/sampleTrCustomComment.lua
+++ b/gettext-gradle-plugin/src/test/resources/sampleTrCustomComment.lua
@@ -1,0 +1,9 @@
+npc:say(GetText:tr("Simple"))
+
+npc:say(GetText:tr("Multi " .. "part"))
+
+local ref1 = "Variable Ref"
+npc:say(GetText:tr(ref1))
+
+-- #. Comment 1
+npc:say(GetText:tr("Tr with args and comment", 1))


### PR DESCRIPTION
This PR adds in a couple new features:

The ability to exclude globbed files with the `exclude` or `excludes` config. They work the same, but `excludes` allows passing in an array of glob paths.

The ability to set the `commentFormat` for extracting out comments. I keep strict formatting rules, which will auto expand comments like `//#.A comment here` to `// #. A comment here` with the setting of ` #. `, so allowing this to be passed in will allow customisation of how the parser extracts comments, so I can keep my strict formatting.

The default value for `commentFormat` is what it was hardcoded to previously, being `#.`

I've written a test case for Java and lua to test `commentFormat` to ensure existing cases work fine, and the new config will extract correctly.

Lastly I updated the .gitignore to exclude deeply and add `.project` to the ignore list. I use Visual Studio Code and the current gitignore didn't exclude the right directories.

This is the first time I've worked with gradle plugins, so please let me know if there's anything wrong or if something can be done better so I know for future :)

Hopefully you find this useful.